### PR TITLE
Drop old Puppet versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.4.0 <7.0.0"
+      "version_requirement": ">=5.5.10 <7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Bump upper bound to cover 6.x.